### PR TITLE
Feat/37 scen config

### DIFF
--- a/Assets/Scripts/Configurations/ConfigHost.cs
+++ b/Assets/Scripts/Configurations/ConfigHost.cs
@@ -5,14 +5,17 @@ namespace Assets.Scripts.Configurations
 {
     public static class ConfigHost
     {
-        public static AppSettings AppSettings { get; private set; }
+        private static AppSettings _appSettings;
+
+        public static AppSettings AppSettings
+            => _appSettings ?? throw new Exception($"{nameof(ConfigHost)} is not initialized properly.");
 
         public static void Initialize(AppSettings appSettings)
         {
-            if (AppSettings != null)
-                throw new InvalidOperationException("ConfigHost is already initialized.");
+            if (_appSettings != null)
+                throw new InvalidOperationException($"{nameof(ConfigHost)} is already initialized.");
 
-            AppSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
+            _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
         }
     }
 }

--- a/Assets/Scripts/Models/Config/AppSettings.cs
+++ b/Assets/Scripts/Models/Config/AppSettings.cs
@@ -1,18 +1,18 @@
-﻿using System;
-
-namespace Assets.Scripts.Models.Config
+﻿namespace Assets.Scripts.Models.Config
 {
     public record AppSettings
     {
         public AppMode Mode;
         public UsbSettings UsbSettings;
+        public SceneSettings SceneSettings;
 
         internal static AppSettings GetDefault()
         {
             return new AppSettings
             {
                 Mode = AppMode.Prod,
-                UsbSettings = UsbSettings.GetDefault()
+                UsbSettings = UsbSettings.GetDefault(),
+                SceneSettings = SceneSettings.GetDefault()
             };
         }
     }

--- a/Assets/Scripts/Models/Config/EulerAngles.cs
+++ b/Assets/Scripts/Models/Config/EulerAngles.cs
@@ -1,0 +1,9 @@
+namespace Assets.Scripts.Models.Config
+{
+    public record EulerAngles
+    {
+        public float X;
+        public float Y;
+        public float Z;
+    }
+}

--- a/Assets/Scripts/Models/Config/EulerAngles.cs.meta
+++ b/Assets/Scripts/Models/Config/EulerAngles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd9a086c859e80f4aa5034612cfa7f33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/Config/SceneSettings.cs
+++ b/Assets/Scripts/Models/Config/SceneSettings.cs
@@ -1,0 +1,19 @@
+namespace Assets.Scripts.Models.Config
+{
+    public record SceneSettings
+    {
+        public int CameraStartOrientation;
+        public float CameraStartDistance;
+        public EulerAngles CubesatStartRotation;
+
+        internal static SceneSettings GetDefault()
+        {
+            return new SceneSettings
+            {
+                CameraStartOrientation = 1,
+                CameraStartDistance = 70f,
+                CubesatStartRotation = new EulerAngles()
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Models/Config/SceneSettings.cs.meta
+++ b/Assets/Scripts/Models/Config/SceneSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dedfaa43078a5d64fab4d9a63bb93f8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/Config/UsbSettings.cs
+++ b/Assets/Scripts/Models/Config/UsbSettings.cs
@@ -12,7 +12,9 @@ namespace Assets.Scripts.Models.Config
         public int PacketSize;
         public int ReadTimeout;
         public int ReadInterval;
+        [Obsolete]
         public int CameraStartOrientation;
+        [Obsolete]
         public float CameraStartDistance;
 
         internal static UsbSettings GetDefault()

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,15 +1,24 @@
 {
   "Mode": "TestCentralSequence",
   "UsbSettings": {
-    "VendorId": 0x7CBA,
-    "ProductId": 0x0ABC,
+    "VendorId": 31930,
+    "ProductId": 2748,
     "Interface": 0,
-    "Endpoint": 0x81,
+    "Endpoint": 129,
     "TransferType": "Bulk",
     "PacketSize": 512,
     "ReadTimeout": 500,
     "ReadInterval": 100,
     "CameraStartOrientation": 1,
     "CameraStartDistance": 100
+  },
+  "SceneSettings": {
+    "CameraStartOrientation": 1,
+    "CameraStartDistance": 100,
+    "CubesatStartRotation": {
+      "X": 0,
+      "Y": 0,
+      "Z": 0
+    }
   }
 }


### PR DESCRIPTION
- Przeniesienie konfiguracji sceny i kamery do osobnej sekcji ustawień.
- Dodanie pola "CubesatStartRotation" do ustawień, które będzie odpowiadać za startową orientacja (kąt) samego CubeSat. Do odczytania i ustawienia na początku sceny.